### PR TITLE
Add functionality to write XML nodes without exclusions

### DIFF
--- a/src/Microsoft.IdentityModel.Xml/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Xml/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
+Microsoft.IdentityModel.Xml.XmlTokenStream.WriteToWithoutExclusions(System.Xml.XmlWriter writer) -> void
 override Microsoft.IdentityModel.Xml.XmlValidationException.StackTrace.get -> string

--- a/src/Microsoft.IdentityModel.Xml/XmlTokenStream.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlTokenStream.cs
@@ -99,6 +99,20 @@ namespace Microsoft.IdentityModel.Xml
             streamWriter.WriteTo(writer, _excludedElement, _excludedElementNamespace);
         }
 
+        /// <summary>
+        /// Writes the XML nodes into the without exclusions <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="writer">the <see cref="XmlWriter"/> to use.</param>
+        /// <exception cref="ArgumentNullException">if <paramref name="writer"/> is null.</exception>
+        public void WriteToWithoutExclusions(XmlWriter writer)
+        {
+            if (writer == null)
+                throw LogArgumentNullException(nameof(writer));
+
+            var streamWriter = new XmlTokenStreamWriter(this);
+            streamWriter.WriteTo(writer);
+        }
+
         internal ReadOnlyCollection<XmlToken> XmlTokens => _xmlTokens.AsReadOnly();
     }
 }


### PR DESCRIPTION

Add functionality to write XML nodes without exclusions. This allows us to include the signature in the assertion XML